### PR TITLE
Fixes for Firefox

### DIFF
--- a/jquery.fs.selecter.js
+++ b/jquery.fs.selecter.js
@@ -1,7 +1,7 @@
 /*
  * Selecter Plugin [Formtone Library]
  * @author Ben Plum
- * @version 1.8.2
+ * @version 1.8.3
  *
  * Copyright © 2012 Ben Plum <mr@benplum.com>
  * Released under the MIT License <http://www.opensource.org/licenses/mit-license.php>
@@ -10,7 +10,8 @@
 if (jQuery) (function($) {
 	
 	// Mobile Detect
-	var agent = isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test( (navigator.userAgent||navigator.vendor||window.opera) );
+	var isFirefox = isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1,
+		agent = isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test( (navigator.userAgent||navigator.vendor||window.opera) );
 	
 	// Default Options
 	var options = {
@@ -384,8 +385,8 @@ if (jQuery) (function($) {
 					data.$selected.trigger("click");
 				}
 			} else {
-				if (e.keyCode == 38 || e.keyCode == 40) {
-					// Up/down increment 
+				if ($.inArray(e.keyCode, (isFirefox) ? [38, 40, 37, 39] : [38, 40]) > -1) {
+					// Increment / decrement using the arrow keys
 					index = data.index + ((e.keyCode == 38) ? -1 : 1);
 					if (index < 0) {
 						index = 0;
@@ -405,7 +406,7 @@ if (jQuery) (function($) {
 						}
 					}
 					
-					// If not, start from the begining
+					// If not, start from the beginning
 					if (index < 0) {
 						for (i = 0; i <= total; i++) {
 							var letter = data.$optionEls.eq(i).text().charAt(0).toUpperCase();
@@ -436,7 +437,7 @@ if (jQuery) (function($) {
 			
 			// Modify DOM
 			if (!data.multiple) {
-				data.$optionEls.attr("selected", null);
+				if (!isFirefox) data.$optionEls.attr("selected", null);
 				data.$selected.html(newLabel);
 				data.$items.filter(".selected").removeClass("selected");
 			}


### PR DESCRIPTION
Version 1.8.2 of Selecter has issues that prevent it from working correctly in Firefox 18.0.1 (and earlier) on Mac 10.8.2 and Windows. Here are the fixes.
1. On line 388, I've added support for the left and right arrow keys. Follow the steps below to see why:
   - Make the native select element (with the class "selecter-element") visible on your demo page's ["Basic" example](http://www.benplum.com/formstone/selecter/).
   - Use the left and right arrows to increment / decrement the focused select element.
   - Notice that while the native element is updated, the corresponding Selecter element (with the class "selecter-selected") does not change. As far as I can tell, Firefox is the only browser that supports left and right arrow key presses on select elements.
2. Line 440 is not needed for Firefox and is actually causing some very odd behavior when used with the up and down arrow keys. Try the following to recreate one of the issues:
   - Use the up arrow to increment / decrement the focused Selecter.
   - Notice that in the "Basic" example, the native select element stops at "Two" and only continues after the Selecter element has reached its final option. Although the selected attribute is updated correctly on the native element, the value sent to the server on submit matches the visible option's value on the native element (as opposed to the option with the "selected" attribute).
   - You may also need to change line 454 to the following, as I have not done any testing with option groups yet:

`if (!isFirefox) data.$optionEls.eq(index).attr("selected", null);`

Thanks for this fantastic plugin!
