### PR TITLE
Options were being opened always on the top if the class "bottom" was added before.

### DIFF
--- a/jquery.fs.selecter.js
+++ b/jquery.fs.selecter.js
@@ -399,6 +399,7 @@
 		if (data.$selecter.hasClass("open")) {
 			data.$itemsWrapper.hide();
 			data.$selecter.removeClass("open").addClass("closed");
+			data.$selecter.removeClass("bottom");
 			$("body").off(".selecter-" + data.guid);
 		}
 	}


### PR DESCRIPTION
Class "bottom" was not being removed after the options were closed.
Options were being opened always on the top if the class "bottom" was added before.
