### PR TITLE
improve selector to find originalOption

### DIFF
--- a/jquery.fs.selecter.js
+++ b/jquery.fs.selecter.js
@@ -212,7 +212,7 @@
 			}
 
 			// Test for selected option in case we need to override the custom label
-			var $originalOption = $select.find("[selected]");
+			var $originalOption = $select.find(":selected");
 			if (!opts.multiple && opts.label !== "" && $originalOption.length < 1) {
 				$select.prepend('<option value="" class="selecter-placeholder" selected>' + opts.label + '</option>');
 			} else {


### PR DESCRIPTION
the selector `:selected` is used in all places except to find the originalOption because it assumes the `selected` prop is set on the original html. But in some usecases, such as setting the value with JavaScript  `$(element).val('value')` before Selecter is initialized this fails because no `selected` attribute is written to the DOM. By changing the selector to `:selected` both usecases are covered. 
