### PR TITLE
Added triggering the change event on the select element when the selected is updated

### DIFF
--- a/jquery.fs.selecter.js
+++ b/jquery.fs.selecter.js
@@ -643,7 +643,7 @@
 	function _onKeypress(e) {
 		var data = e.data;
 
-		if (e.keyCode === 13) {
+		if (e.keyCode === 13 || e.keyCode === 9) {
 			if (data.$selecter.hasClass("open")) {
 				_onClose(e);
 				_update(data.index, data);

--- a/src/jquery.fs.selecter.js
+++ b/src/jquery.fs.selecter.js
@@ -643,7 +643,7 @@
 	function _onKeypress(e) {
 		var data = e.data;
 
-		if (e.keyCode === 13) {
+		if (e.keyCode === 13 || e.keyCode === 9) {
 			if (data.$selecter.hasClass("open")) {
 				_onClose(e);
 				_update(data.index, data);


### PR DESCRIPTION
I need this for an AngularJS project. The ng-model is not updated when changing selecter options using the arrows. While the value of the select element is changed the change event is not triggered resulting in not updating the ng-model of the select.

Another requirement was to select an option by pressing "tab" along with "enter". This is a nice feature to have.
